### PR TITLE
🔧 chore(config): update customManagers configuration

### DIFF
--- a/default.json
+++ b/default.json
@@ -68,8 +68,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^rust-toolchain\\.toml?$"
+      "managerFilePatterns": [
+        "/^rust-toolchain\\.toml?$/"
       ],
       "matchStrings": [
         "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+\\.\\d+)\""


### PR DESCRIPTION
- rename fileMatch to managerFilePatterns for consistency with updated naming conventions