### PR TITLE
🔧 chore(config): add group name for pinned containers

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 🔧 chore(ci)-update manager file patterns in ciContainerDigest(pr [#50])
 - 🔧 chore(ci)-update yaml file pattern in container digest(pr [#51])
 - 🔧 chore(config)-update test tools group name in package configuration(pr [#53])
+- 🔧 chore(config)-add group name for pinned containers(pr [#56])
 
 ### Fixed
 
@@ -90,3 +91,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#53]: https://github.com/digital-prstv/renovate-config/pull/53
 [#55]: https://github.com/digital-prstv/renovate-config/pull/55
 [#54]: https://github.com/digital-prstv/renovate-config/pull/54
+[#56]: https://github.com/digital-prstv/renovate-config/pull/56

--- a/default.json
+++ b/default.json
@@ -23,7 +23,8 @@
         "node"
       ],
       "versioning": "docker",
-      "pinDigests": true
+      "pinDigests": true,
+      "groupName": "pinned containers"
     },
     {
       "groupName": "futures packages",


### PR DESCRIPTION
- add "groupName" field to the configuration for pinned containers to enhance clarity and organization

Signed-off-by: Jeremiah Russell <jerry@jrussell.ie>