### PR TITLE
feat: group rand packages

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BREAKING: migrate to circleci-toolkit v4.2.1(pr [#39])
 - ✨ enable pinning of digests in config(pr [#41])
 - ✨ enable Docker digest tracking for ci-rust(pr [#43])
+- group rand packages(pr [#58])
 
 ### Changed
 
@@ -94,3 +95,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#54]: https://github.com/digital-prstv/renovate-config/pull/54
 [#56]: https://github.com/digital-prstv/renovate-config/pull/56
 [#57]: https://github.com/digital-prstv/renovate-config/pull/57
+[#58]: https://github.com/digital-prstv/renovate-config/pull/58

--- a/default.json
+++ b/default.json
@@ -27,6 +27,12 @@
       "groupName": "pinned containers"
     },
     {
+      "groupName": "rand packages",
+      "matchPackageNames": [
+        "/^rand[-_]?/"
+      ]
+    },
+    {
       "groupName": "futures packages",
       "matchPackageNames": [
         "/^futures[-_]?/"


### PR DESCRIPTION
## Summary

Add `rand packages` group to ensure `rand`, `rand_chacha`, `rand_core`, and related crates are always updated together.

## Why

`rand_chacha`'s version tracks `rand`'s — they share `rand_core` as a common dependency. When Renovate bumped `rand 0.9→0.10` without also bumping `rand_chacha`, the two crates resolved to different versions of `rand_core` (0.9 vs 0.10). This caused `ChaCha20Rng` to no longer satisfy the `Rng` trait bound, breaking compilation in wpsr (pipeline #1283).

The `/^rand[-_]?/` pattern covers: `rand`, `rand_chacha`, `rand_core`, `rand_distr`, `rand_pcg`, `rand_xorshift`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)