### PR TITLE
feat: group git2 packages

### DIFF
--- a/default.json
+++ b/default.json
@@ -27,6 +27,12 @@
       "groupName": "pinned containers"
     },
     {
+      "groupName": "git2 packages",
+      "matchPackageNames": [
+        "/^git2[-_]?/"
+      ]
+    },
+    {
       "groupName": "rand packages",
       "matchPackageNames": [
         "/^rand[-_]?/"


### PR DESCRIPTION
## Summary

- Add `git2 packages` group so `git2` and `git2_credentials` are always upgraded in the same PR
- `git2_credentials` re-exports `git2` types (`Config`, `Cred`, `CredentialType`) in its public API — upgrading `git2` alone creates a version diamond that fails to compile

## Context

jerus-org/pcu#955 (Renovate bumped only `git2` to `0.21.0`) failed validation because `git2_credentials 0.15.0` still depends on `git2 0.20.4`. This group rule prevents that class of breakage across all repos.

The pattern follows the existing `rand packages`, `serde packages`, etc. groups.

## Test plan

- [ ] CI passes
- [ ] After merge, close jerus-org/pcu#955 and close/revert jerus-org/pcu#958 (local renovate.json workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)