### PR TITLE
👷 ci(circleci): remove unused orb configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  toolkit: digital-prstv/circleci-toolkit@6.2.0
-
 executors:
   node:
     docker:

--- a/default.json
+++ b/default.json
@@ -33,6 +33,12 @@
       ]
     },
     {
+      "groupName": "hashicorp terraform",
+      "matchPackageNames": [
+        "/^hashicorp/"
+      ]
+    },
+    {
       "groupName": "rand packages",
       "matchPackageNames": [
         "/^rand[-_]?/"


### PR DESCRIPTION
- delete digital-prstv/circleci-toolkit orb from config.yml to clean up unused dependencies

🔧 chore(config): add terraform package grouping

- include a new group for hashicorp terraform packages in default.json

Signed-off-by: Jeremiah Russell <jerry@jrussell.ie>