### PR TITLE
fix: track orbs in @orb.yml source manifests

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,6 +6,11 @@
   "semanticCommits": "enabled",
   "semanticCommitType": "fix",
   "versioning": "cargo",
+  "circleci": {
+    "fileMatch": [
+      "/(^|/)@orb\\.yml$/"
+    ]
+  },
   "hostRules": [
     {
       "matchHost": "circleci.com",


### PR DESCRIPTION
## Summary

Makes Renovate track orbs declared in an orb's own **source manifest** (`src/@orb.yml` / `orb/src/@orb.yml`), not just orbs in `.circleci/*.yml`.

## Problem

Renovate's `circleci` manager scans `.circleci/*.yml` but **not** orb source manifests. In `circleci-toolkit`, the `codecov`, `sonarcloud`, and `node` orbs are declared in `src/@orb.yml`, so Renovate never saw them — they silently went stale. This is why the **codecov `5.0.1 → 6.0.0`** bump (required to fix the org-wide `gpg: no valid OpenPGP data found` Codecov upload failure that started 2026-06-07) had to be done manually.

The repo's Renovate Dependency Dashboard confirmed it: under `circleci` it listed only `.circleci/config.yml`, `release.yml`, `test-deploy.yml`, `update_prlog.yml` — never `src/@orb.yml`.

## Fix

```json
"circleci": {
  "fileMatch": ["/(^|/)@orb\\.yml$/"]
}
```

- **Additive** to Renovate's default `circleci` patterns — `.circleci/*.yml` detection is unchanged.
- Matches `src/@orb.yml` (circleci-toolkit) and `orb/src/@orb.yml` (gen-circleci-orb, gen-orb-mcp, zola-orb).
- No-op for non-orb repos (no `@orb.yml`).
- Every repo extending this config picks it up automatically on its next Renovate run — no per-repo change needed.

Validated with `renovate-config-validator` (Config validated successfully). `fileMatch` is used rather than `managerFilePatterns` because the validator rejects the latter under a built-in manager scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
