### PR TITLE
fix: add sdk specifically to group

### DIFF
--- a/default.json
+++ b/default.json
@@ -78,6 +78,7 @@
       "groupName": "opentelemetry packages",
       "matchPackageNames": [
         "/^opentelemetry[-_]?/",
+	"opentelemetry_sdk",
         "tracing-opentelemetry"
       ]
     },

--- a/default.json
+++ b/default.json
@@ -78,7 +78,7 @@
       "groupName": "opentelemetry packages",
       "matchPackageNames": [
         "/^opentelemetry[-_]?/",
-	"opentelemetry_sdk",
+        "opentelemetry_sdk",
         "tracing-opentelemetry"
       ]
     },


### PR DESCRIPTION
## Problem

opentelemetry_sdk is not picked up as part of the group and changed in step.

## Solution

Explicitly add the crate as a member of the group instead of relying on the regex. 